### PR TITLE
Feature/fix prefix

### DIFF
--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -76,7 +76,7 @@ module AssetSync
         elsif File.exist?(self.config.manifest_path)
           log "Using: Manifest #{self.config.manifest_path}"
           yml = YAML.load(IO.read(self.config.manifest_path))
-   
+
           return yml.map do |original, compiled|
             # Upload font originals and compiled
             if original =~ /^.+(eot|svg|ttf|woff)$/
@@ -91,7 +91,13 @@ module AssetSync
       end
       log "Using: Directory Search of #{path}/#{self.config.assets_prefix}"
       Dir.chdir(path) do
-        to_load = self.config.assets_prefix.present? ? "#{self.config.assets_prefix}/**/**" : '**/**'
+        # So we may want to set the prefix something like 'prefix/'
+        # to prevent fuzzy folder matching in get_remote_files
+        # but that will cause issues with the folder expansion below in to_load
+        # So here we check if the prefix ends with a '/', and remove it as needed before
+        # looking for files.
+        path_prefix = self.config.assets_prefix.sub(/\/$/, '')
+        to_load = self.config.assets_prefix.present? ? "#{path_prefix}/**/**" : '**/**'
         Dir[to_load]
       end
     end

--- a/lib/asset_sync/version.rb
+++ b/lib/asset_sync/version.rb
@@ -1,3 +1,3 @@
 module AssetSync
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end


### PR DESCRIPTION
@Tapjoy/eng-group-ops @andyleclair @jjrussell 

So here's the deal. 

The AssetSync gem lists out the remote files from s3 and the list of local files it needs to sync if it determines we want to keep and not overwrite the versions of the files that might already exist in the S3 bucket (our desired behavior in TJS). This causes a problem because the bucket list call does fuzzy matching on the prefix, so it doesn't distinguish between...I dunno say a folder called assets/ and a folder called asset-5rocks-server/ that has 50 kabillion files in it. So we may want the prefix to be more specific and use a trailing slash('assets/'), but if we do that, It would break the folder expansion in get_local_assets.

This fixes that. 
