### PR TITLE
V2.0.0 and path glob fix

### DIFF
--- a/lib/asset_sync/storage.rb
+++ b/lib/asset_sync/storage.rb
@@ -78,7 +78,8 @@ module AssetSync
       end
       log "Using: Directory Search of #{path}/#{self.config.assets_prefix}"
       Dir.chdir(path) do
-        to_load = self.config.assets_prefix.present? ? "#{self.config.assets_prefix}/**/**" : '**/**'
+        # Using file join allows the asset_prefix to have a trailing slash without breaking the glob pattern.
+        to_load = self.config.assets_prefix.present? ? File.join(self.config.assets_prefix, '**', '*') : '**/*'
         Dir[to_load]
       end
     end

--- a/lib/asset_sync/version.rb
+++ b/lib/asset_sync/version.rb
@@ -1,3 +1,3 @@
 module AssetSync
-  VERSION = "2.0.0"
+  VERSION = "2.0.0.1"
 end


### PR DESCRIPTION
Similar to https://github.com/Tapjoy/asset_sync/pull/1 but uses `File.join` instead of modifying the string directly. Also will put us on 2.0 which will relax the dependency on fog so we can only depend on fog-aws with TJS.

The set of changes from 1.1 to 2.0 is in the [CHANGELOG](https://github.com/AssetSync/asset_sync/blob/master/CHANGELOG.md) and should pose no issues.